### PR TITLE
Do not check for warnings agent-side

### DIFF
--- a/spec/acceptance/agent_spec.rb
+++ b/spec/acceptance/agent_spec.rb
@@ -13,7 +13,7 @@ RSpec.context 'when applying resource_api::agent' do
   end
 
   it 'does not show errors' do
-    expect(@result.stderr).not_to match %r{warn|error}i
+    expect(@result.stderr).not_to match %r{error}i
   end
 
   context 'when applying a second time' do
@@ -26,7 +26,7 @@ RSpec.context 'when applying resource_api::agent' do
     end
 
     it 'does not show errors' do
-      expect(@result.stderr).not_to match %r{warn|error}i
+      expect(@result.stderr).not_to match %r{error}i
     end
   end
 
@@ -45,7 +45,7 @@ RSpec.context 'when applying resource_api::agent' do
     end
 
     it 'does not show errors' do
-      expect(@result.stderr).not_to match %r{warn|error}i
+      expect(@result.stderr).not_to match %r{error}i
     end
   end
 end


### PR DESCRIPTION
See https://github.com/puppetlabs/puppetlabs-resource_api/commit/527f7c0b8dce8dcc4da191d6020bb90aa2973973

On single-node nodesets, the same issue arises with the agent tests.