### PR TITLE
Disable extensive debugging on acceptance testing

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -3,7 +3,7 @@ require 'beaker/module_install_helper'
 require 'beaker/puppet_install_helper'
 
 def beaker_opts
-  { debug: true, trace: true, expect_failures: true, acceptable_exit_codes: (0...256) }
+  { debug: false, trace: true, expect_failures: true, acceptable_exit_codes: (0...256) }
   # { expect_failures: true, acceptable_exit_codes: (0...256) }
 end
 


### PR DESCRIPTION
Due to facter's dmidecode dump filling up the log files, the
debug output is pretty near unusable. This change disables
all debug output.