### PR TITLE
(PDK-881) update acceptance tests to match new behaviour on puppet6

### DIFF
--- a/spec/acceptance/agent_spec.rb
+++ b/spec/acceptance/agent_spec.rb
@@ -9,7 +9,13 @@ RSpec.context 'when applying resource_api::agent' do
   end
 
   it 'runs with changes and without errors' do
+    skip 'on puppet 6, no changes expected' unless puppet6?
     expect(@result.exit_code).to eq 2
+  end
+
+  it 'runs with no changes and without errors' do
+    skip 'not on puppet 6, changes expected' if puppet6?
+    expect(@result.exit_code).to eq 0
   end
 
   it 'does not show errors' do

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -19,7 +19,13 @@ MANIFEST
   end
 
   it 'runs with changes and without errors' do
+    skip 'on puppet 6, no changes expected' unless puppet6?
     expect(@result.exit_code).to eq 2
+  end
+
+  it 'runs with no changes and without errors' do
+    skip 'not on puppet 6, changes expected' if puppet6?
+    expect(@result.exit_code).to eq 0
   end
 
   it 'does not show errors' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,6 +7,12 @@ def beaker_opts
   # { expect_failures: true, acceptable_exit_codes: (0...256) }
 end
 
+# determine whether or not we're on puppet 6, which has the gem integrated
+# if the gem is integrated, we do not want to install over it
+def puppet6?
+  @__puppet6 ||= Gem::Version.new(fact_on(default, 'puppetversion')) >= Gem::Version.new('6.0.0')
+end
+
 RSpec.configure do |c|
   c.before :suite do
     unless ENV['BEAKER_provision'] == 'no'


### PR DESCRIPTION
Local test run:
```
Pending: (Failures listed here are expected and do not affect your suite's status)

  1) when applying resource_api::agent runs with changes and without errors
     # on puppet 6, no changes expected
     # ./spec/acceptance/agent_spec.rb:11


Finished in 54.33 seconds (files took 22.52 seconds to load)
8 examples, 0 failures, 1 pending
```