### PR TITLE
POC implement a standardized install class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,43 @@
+
 # resource_api
 
 #### Table of Contents
 
-1. [Description](#description)
-2. [Setup - The basics of getting started with resource_api](#setup)
+1. [Module Description - What the module does and why it is useful](#module-description)
+1. [Setup - The basics of getting started with resource_api](#setup)
     * [What resource_api affects](#what-resource_api-affects)
     * [Setup requirements](#setup-requirements)
     * [Beginning with resource_api](#beginning-with-resource_api)
-3. [Usage - Configuration options and additional functionality](#usage)
-4. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
-5. [Limitations - OS compatibility, etc.](#limitations)
-6. [Development - Guide for contributing to the module](#development)
+1. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
+1. [Development - Guide for contributing to the module](#development)
 
-## Description
+## Module Description
 
-This module installs the Resource API gem into your PE, puppetserver and
-puppet-agent installations. This is necessary to use any type and provider that's implemented using the Resource API.
+This module installs the Puppet Resource API gem into a puppet agent and pe-pupetserver or puppetserver service. This is necessary to use any type or provider that is implemented using the Puppet Resource API.
 
 ## Setup
 
 ### What resource_api affects
 
-The Resource API will get installed into your PE or puppetserver installation
-using the puppetserver_gem utility. To activate it a reload of the puppetserver
-is necessary. In most cases this should work automatically and cause little to
-no interruption to your service.
+The Puppet Resource API gem will be installed into a puppet agent using the `puppet_gem` provider, and into a puppetserver service using the `puppetserver_gem` provider. To activate the gem, a reload of the puppetserver service is necessary. In most cases, this should happen automatically and cause little to no interruption to service.
 
 ### Setup Requirements
 
-The Resource API is only compatible with puppet 4.7 and later. There are no
-further specific requirements.
+The Puppet Resource API is only compatible with Puppet 4.7 and later.
+There are no further specific requirements.
 
 ### Beginning with resource_api
 
-To be able to use Resource API providers, two things need to happen:
+To install dependencies of the Puppet Resource API:
 
-* on each puppetserver or PE master that needs to process Resource API providers, classify or apply the `resource_api::server` class.
+1. Classify or apply the `resource_api` class on each master (master of masters, and if present, compile masters and replica master) that needs to process Puppet Resource API types and providers.
+1. Classify or apply the `resource_api` class on each puppet agent that needs to apply Puppet Resource API types and providers.
 
-* on each puppet agent that needs to apply Resource API providers, classify or apply the `resource_api::agent` class.
+To specify the version of the Puppet Resource API gem to be installed, instead use the `resource_api::install::agent` class and its `$api_version` parameter.
 
-You can use the `$api_version` parameter to select which version of the Resource API gem gets installed.
+To specify a non-default `puppetserver` service resource (if you're not using the standard service) instead use the `resource_api::install::master` class and its `$puppetserver_service` parameter.
 
-You can use the `$puppetserver_service` parameter on the `resource_api::server` class to specify a non-default `puppetserver` service resource, if you're not using the standard ones.
+Run `puppet agent -t` on the master(s) before using the Puppet Resource API on the agent(s).
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # resource_api
 
 #### Table of Contents

--- a/lib/facter/puppetserver_installed.rb
+++ b/lib/facter/puppetserver_installed.rb
@@ -1,0 +1,9 @@
+# As per: lib/puppet/provider/package/puppetserver_gem.rb ...
+#
+#   commands :puppetservercmd => "/opt/puppetlabs/bin/puppetserver"
+
+Facter.add('puppetserver_installed') do
+  setcode do
+    File.file?('/opt/puppetlabs/bin/puppetserver')
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,3 @@
+class resource_api {
+  class { 'resource_api::install': }
+}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,23 @@
+# Install resource_api module dependencies on a puppet agent or master.
+#
+# A proxy agent needs to be classified with this class before it can use
+# device modules that use the resource_api.
+#
+# Every master: master of masters, and if present, compile masters and replica
+# needs to be classified with this class before it can compile catalogs for
+# device modules that use the resource_api.
+#
+# @summary Install dependencies into the puppet agent and puppetserver service
+#
+# @example
+#   include resource_api::install
+
+class resource_api::install {
+
+  include resource_api::install::agent
+
+  if $facts['puppetserver_installed'] {
+    include resource_api::install::master
+  }
+
+}

--- a/manifests/install/agent.pp
+++ b/manifests/install/agent.pp
@@ -1,0 +1,26 @@
+# Install resource_api module dependencies on a puppet agent.
+
+# A proxy agent needs to be classified with this class before it can use
+# device modules that use the resource_api.
+
+# @summary Install dependencies into the puppet agent
+#
+# @example
+#   include resource_api::install::agent
+#
+# @param [String] api_version A specific release version of Resource API to install
+
+class resource_api::install::agent(
+  String $api_version = 'latest',
+) {
+
+  if versioncmp($facts['puppetversion'], '6.0.0') < 0 {
+    package { 'Resource API on the puppet AIO':
+      ensure   => $api_version,
+      name     => 'puppet-resource_api',
+      provider => puppet_gem,
+    }
+  }
+
+}
+

--- a/manifests/install/master.pp
+++ b/manifests/install/master.pp
@@ -1,0 +1,36 @@
+# Install resource_api module dependencies on a puppet master.
+
+# Every master: master of masters, and if present, compile masters and replica
+# needs to be classified with this class before it can compile catalogs for
+# device modules that use the resource_api.
+
+# @summary Install dependencies into the puppetserver service and restart
+#
+# @example
+#   include resource_api::install::master
+#
+# @param [String] api_version A specific release version of Resource API to install
+# @param [Type[Resource]] puppetserver_service The name of the puppetserver service to restart
+
+class resource_api::install::master(
+  String $api_version = 'latest',
+  Type[Resource] $puppetserver_service = $facts['pe_server_version'] ? {
+    /./     => Service['pe-puppetserver'],
+    default => Service['puppetserver']
+  },
+) {
+
+  # Since PE and Puppet are bundled together, it is enough to only check for the puppet version here.
+
+  if versioncmp($facts['puppetversion'], '6.0.0') < 0 {
+    package { 'Resource API on the puppetserver':
+      ensure   => $api_version,
+      name     => 'puppet-resource_api',
+      provider => puppetserver_gem,
+    }
+
+    Package['Resource API on the puppetserver'] ~> $puppetserver_service
+  }
+
+}
+


### PR DESCRIPTION
With this commit ...

Simply including the module will include the ::install class.
The ::install class will install dependencies on agent or master.

(A custom puppetserver_installed fact is defined to detect a master.)

Optionally, the ::install::agent and ::install::master classes can be declared
directly, allowing the user to specify their parameters ... if any.

Simplify/normalize documentation.

TODO: Deprecate/remove the ::agent and ::server classes.