### PR TITLE
(FM-7653) implement a standardized install class

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ To install dependencies of the Puppet Resource API:
 1. Classify or apply the `resource_api` class on each master (master of masters, and if present, compile masters and replica master) that needs to process Puppet Resource API types and providers.
 1. Classify or apply the `resource_api` class on each puppet agent that needs to apply Puppet Resource API types and providers.
 
-To specify the version of the Puppet Resource API gem you want to install, use the `resource_api::install::agent` class and its `$api_version` parameter.
+To specify the version of the Puppet Resource API gem you want to install, use the `$api_version` parameter with the `resource_api::install::master` and `resource_api::install::agent` classes instead of using the `resource_api` class.
 
-To specify a non-default `puppetserver` service resource (if you're not using the standard service) use the `resource_api::install::master` class and its `$puppetserver_service` parameter.
+To specify a non-default `puppetserver` service resource (if you're not using the standard service) use the `$puppetserver_service` parameter with the  `resource_api::install::master` class instead of using the `resource_api` class.
 
 Run `puppet agent -t` on the master(s) before using the Puppet Resource API on the agent(s).
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,43 @@
+
 # resource_api
 
 #### Table of Contents
 
-1. [Description](#description)
-2. [Setup - The basics of getting started with resource_api](#setup)
+1. [Module Description - What the module does and why it is useful](#module-description)
+1. [Setup - The basics of getting started with resource_api](#setup)
     * [What resource_api affects](#what-resource_api-affects)
     * [Setup requirements](#setup-requirements)
     * [Beginning with resource_api](#beginning-with-resource_api)
-3. [Usage - Configuration options and additional functionality](#usage)
-4. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
-5. [Limitations - OS compatibility, etc.](#limitations)
-6. [Development - Guide for contributing to the module](#development)
+1. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
+1. [Development - Guide for contributing to the module](#development)
 
-## Description
+## Module Description
 
-This module installs the Resource API gem into your PE, puppetserver and
-puppet-agent installations. This is necessary to use any type and provider that's implemented using the Resource API.
+This module installs the Puppet Resource API gem into a puppet agent and pe-pupetserver or puppetserver service. This is necessary to use any type or provider that is implemented using the Puppet Resource API.
 
 ## Setup
 
 ### What resource_api affects
 
-The Resource API will get installed into your PE or puppetserver installation
-using the puppetserver_gem utility. To activate it a reload of the puppetserver
-is necessary. In most cases this should work automatically and cause little to
-no interruption to your service.
+The Puppet Resource API gem will be installed into a puppet agent using the `puppet_gem` provider, and into a puppetserver service using the `puppetserver_gem` provider. To activate the gem, a reload of the puppetserver service is necessary. In most cases, this should happen automatically and cause little to no interruption to service.
 
 ### Setup Requirements
 
-The Resource API is only compatible with puppet 4.7 and later. There are no
-further specific requirements.
+The Puppet Resource API is only compatible with Puppet 4.7 and later.
+There are no further specific requirements.
 
 ### Beginning with resource_api
 
-To be able to use Resource API providers, two things need to happen:
+To install dependencies of the Puppet Resource API:
 
-* on each puppetserver or PE master that needs to process Resource API providers, classify or apply the `resource_api::server` class.
+1. Classify or apply the `resource_api` class on each master (master of masters, and if present, compile masters and replica master) that needs to process Puppet Resource API types and providers.
+1. Classify or apply the `resource_api` class on each puppet agent that needs to apply Puppet Resource API types and providers.
 
-* on each puppet agent that needs to apply Resource API providers, classify or apply the `resource_api::agent` class.
+To specify the version of the Puppet Resource API gem to be installed, instead use the `resource_api::install::agent` class and its `$api_version` parameter.
 
-You can use the `$api_version` parameter to select which version of the Resource API gem gets installed.
+To specify a non-default `puppetserver` service resource (if you're not using the standard service) instead use the `resource_api::install::master` class and its `$puppetserver_service` parameter.
 
-You can use the `$puppetserver_service` parameter on the `resource_api::server` class to specify a non-default `puppetserver` service resource, if you're not using the standard ones.
+Run `puppet agent -t` on the master(s) before using the Puppet Resource API on the agent(s).
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ To install dependencies of the Puppet Resource API:
 1. Classify or apply the `resource_api` class on each master (master of masters, and if present, compile masters and replica master) that needs to process Puppet Resource API types and providers.
 1. Classify or apply the `resource_api` class on each puppet agent that needs to apply Puppet Resource API types and providers.
 
-To specify the version of the Puppet Resource API gem to be installed, instead use the `resource_api::install::agent` class and its `$api_version` parameter.
+To specify the version of the Puppet Resource API gem you want to install, use the `resource_api::install::agent` class and its `$api_version` parameter.
 
-To specify a non-default `puppetserver` service resource (if you're not using the standard service) instead use the `resource_api::install::master` class and its `$puppetserver_service` parameter.
+To specify a non-default `puppetserver` service resource (if you're not using the standard service) use the `resource_api::install::master` class and its `$puppetserver_service` parameter.
 
 Run `puppet agent -t` on the master(s) before using the Puppet Resource API on the agent(s).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # resource_api
 
 #### Table of Contents

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,14 +6,14 @@
 **Classes**
 
 * [`resource_api`](#resource_api): This class calls the resource_api::install class.
-* [`resource_api::agent`](#resource_apiagent): This class will install the Resource API gem into puppet agent
-* [`resource_api::install`](#resource_apiinstall): This class will install dependencies of the Resource API
+* [`resource_api::agent`](#resource_apiagent): This class installs the Resource API gem into puppet agent
+* [`resource_api::install`](#resource_apiinstall): This class installs dependencies of the Resource API
 into the puppet agent, and/or the puppetserver service.
-* [`resource_api::install::agent`](#resource_apiinstallagent): This class will install the Resource API gem into puppet agent
-* [`resource_api::install::master`](#resource_apiinstallmaster): This class will install the Resource API gem into puppetserver,
-and restart the puppetserver service to activate.
-* [`resource_api::server`](#resource_apiserver): This class will install the Resource API gem into puppetserver,
-and restart the puppetserver service to activate.
+* [`resource_api::install::agent`](#resource_apiinstallagent): This class installs the Resource API gem into puppet agent
+* [`resource_api::install::master`](#resource_apiinstallmaster): This class installs the Resource API gem into puppetserver,
+and restarts the puppetserver service to activate.
+* [`resource_api::server`](#resource_apiserver): This class installs the Resource API gem into puppetserver,
+and restarts the puppetserver service to activate.
 
 ## Classes
 
@@ -31,7 +31,7 @@ include resource_api
 
 ### resource_api::agent
 
-This class will install the Resource API gem into puppet agent
+This class installs the Resource API gem into puppet agent
 
 * **Note** Deprecated, use resource_api::install::agent
 
@@ -57,7 +57,7 @@ Default value: 'latest'
 
 ### resource_api::install
 
-This class will install dependencies of the Resource API
+This class installs dependencies of the Resource API
 into the puppet agent, and/or the puppetserver service.
 
 #### Examples
@@ -70,7 +70,7 @@ include resource_api::install
 
 ### resource_api::install::agent
 
-This class will install the Resource API gem into puppet agent
+This class installs the Resource API gem into puppet agent
 
 #### Examples
 
@@ -94,8 +94,8 @@ Default value: 'latest'
 
 ### resource_api::install::master
 
-This class will install the Resource API gem into puppetserver,
-and restart the puppetserver service to activate.
+This class installs the Resource API gem into puppetserver,
+and restarts the puppetserver service to activate.
 
 #### Examples
 
@@ -127,8 +127,8 @@ Default value: $facts['pe_server_version']
 
 ### resource_api::server
 
-This class will install the Resource API gem into puppetserver,
-and restart the puppetserver service to activate.
+This class installs the Resource API gem into puppetserver,
+and restarts the puppetserver service to activate.
 
 * **Note** Deprecated, use resource_api::install::server
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5,17 +5,35 @@
 
 **Classes**
 
-* [`resource_api::agent`](#resource_apiagent): This class will install the Resource API gem onto the agent
-* [`resource_api::server`](#resource_apiserver): This class will install the Resource API gem onto the server and perform
-a reboot of the server.
+* [`resource_api`](#resource_api): This class calls the resource_api::install class.
+* [`resource_api::agent`](#resource_apiagent): This class will install the Resource API gem into puppet agent
+* [`resource_api::install`](#resource_apiinstall): This class will install dependencies of the Resource API
+into the puppet agent, and/or the puppetserver service.
+* [`resource_api::install::agent`](#resource_apiinstallagent): This class will install the Resource API gem into puppet agent
+* [`resource_api::install::master`](#resource_apiinstallmaster): This class will install the Resource API gem into puppetserver,
+and restart the puppetserver service to activate.
+* [`resource_api::server`](#resource_apiserver): This class will install the Resource API gem into puppetserver,
+and restart the puppetserver service to activate.
 
 ## Classes
 
+### resource_api
+
+This class calls the resource_api::install class.
+
+#### Examples
+
+##### Declaring the class
+
+```puppet
+include resource_api
+```
+
 ### resource_api::agent
 
-resource_api::agent
+This class will install the Resource API gem into puppet agent
 
-Install dependencies onto the agent
+* **Note** Deprecated, use resource_api::install::agent
 
 #### Examples
 
@@ -37,11 +55,82 @@ A specific release version of Resource API to install
 
 Default value: 'latest'
 
+### resource_api::install
+
+This class will install dependencies of the Resource API
+into the puppet agent, and/or the puppetserver service.
+
+#### Examples
+
+##### Declaring the class
+
+```puppet
+include resource_api::install
+```
+
+### resource_api::install::agent
+
+This class will install the Resource API gem into puppet agent
+
+#### Examples
+
+##### Declaring the class
+
+```puppet
+include resource_api::install::agent
+```
+
+#### Parameters
+
+The following parameters are available in the `resource_api::install::agent` class.
+
+##### `api_version`
+
+Data type: `String`
+
+A specific release version of Resource API to install
+
+Default value: 'latest'
+
+### resource_api::install::master
+
+This class will install the Resource API gem into puppetserver,
+and restart the puppetserver service to activate.
+
+#### Examples
+
+##### Declaring the class
+
+```puppet
+include resource_api::install::master
+```
+
+#### Parameters
+
+The following parameters are available in the `resource_api::install::master` class.
+
+##### `api_version`
+
+Data type: `String`
+
+A specific release version of Resource API to install
+
+Default value: 'latest'
+
+##### `puppetserver_service`
+
+Data type: `Type[Resource]`
+
+The name of the puppetserver service to restart
+
+Default value: $facts['pe_server_version']
+
 ### resource_api::server
 
-resource_api::server
+This class will install the Resource API gem into puppetserver,
+and restart the puppetserver service to activate.
 
-Install dependencies onto the server
+* **Note** Deprecated, use resource_api::install::server
 
 #### Examples
 

--- a/lib/facter/puppetserver_installed.rb
+++ b/lib/facter/puppetserver_installed.rb
@@ -1,0 +1,9 @@
+# As per: lib/puppet/provider/package/puppetserver_gem.rb ...
+#
+#   commands :puppetservercmd => "/opt/puppetlabs/bin/puppetserver"
+
+Facter.add('puppetserver_installed') do
+  setcode do
+    File.file?('/opt/puppetlabs/bin/puppetserver')
+  end
+end

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -1,4 +1,4 @@
-# @summary This class will install the Resource API gem into puppet agent
+# @summary This class installs the Resource API gem into puppet agent
 #
 # @example Declaring the class
 #   include resource_api::agent

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -1,16 +1,12 @@
-# resource_api::agent
+# @summary This class will install the Resource API gem into puppet agent
 #
-# Install dependencies onto the agent
-#
-# @summary This class will install the Resource API gem onto the agent
-#
-# @example  Declaring the class
+# @example Declaring the class
 #   include resource_api::agent
 #
-# @param [String] api_version A specific release version of Resource API to install
+# @param [String] api_version
+#   A specific release version of Resource API to install
 #
-# Deprecated by resource_api::install::agent
-
+# @note Deprecated, use resource_api::install::agent
 class resource_api::agent(String $api_version = 'latest') {
   if versioncmp($facts['puppetversion'], '6.0.0') < 0 {
     package { 'Resource API on the puppet AIO':

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -8,6 +8,9 @@
 #   include resource_api::agent
 #
 # @param [String] api_version A specific release version of Resource API to install
+#
+# Deprecated by resource_api::install::agent
+
 class resource_api::agent(String $api_version = 'latest') {
   if versioncmp($facts['puppetversion'], '6.0.0') < 0 {
     package { 'Resource API on the puppet AIO':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,3 @@
+class resource_api {
+  class { 'resource_api::install': }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,7 @@
+# @summary This class calls the resource_api::install class.
+#
+# @example Declaring the class
+#   include resource_api
 class resource_api {
   class { 'resource_api::install': }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,4 @@
-# @summary This class will install dependencies of the Resource API
+# @summary This class installs dependencies of the Resource API
 #          into the puppet agent, and/or the puppetserver service.
 #
 # @example Declaring the class

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,17 +1,8 @@
-# Install resource_api module dependencies on a puppet agent or master.
+# @summary This class will install dependencies of the Resource API
+#          into the puppet agent, and/or the puppetserver service.
 #
-# A proxy agent needs to be classified with this class before it can use
-# device modules that use the resource_api.
-#
-# Every master: master of masters, and if present, compile masters and replica
-# needs to be classified with this class before it can compile catalogs for
-# device modules that use the resource_api.
-#
-# @summary Install dependencies into the puppet agent and puppetserver service
-#
-# @example
+# @example Declaring the class
 #   include resource_api::install
-
 class resource_api::install {
 
   include resource_api::install::agent
@@ -21,3 +12,10 @@ class resource_api::install {
   }
 
 }
+
+# A proxy agent needs to be classified with this class before it can use
+# device modules that use the Resource API.
+#
+# Every master: master of masters, and if present, compile masters and replica
+# needs to be classified with this class before it can compile catalogs for
+# device modules that use the Resource API.

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,23 @@
+# Install resource_api module dependencies on a puppet agent or master.
+#
+# A proxy agent needs to be classified with this class before it can use
+# device modules that use the resource_api.
+#
+# Every master: master of masters, and if present, compile masters and replica
+# needs to be classified with this class before it can compile catalogs for
+# device modules that use the resource_api.
+#
+# @summary Install dependencies into the puppet agent and puppetserver service
+#
+# @example
+#   include resource_api::install
+
+class resource_api::install {
+
+  include resource_api::install::agent
+
+  if $facts['puppetserver_installed'] {
+    include resource_api::install::master
+  }
+
+}

--- a/manifests/install/agent.pp
+++ b/manifests/install/agent.pp
@@ -1,4 +1,4 @@
-# @summary This class will install the Resource API gem into puppet agent
+# @summary This class installs the Resource API gem into puppet agent
 #
 # @example Declaring the class
 #   include resource_api::install::agent
@@ -18,4 +18,3 @@ class resource_api::install::agent(
   }
 
 }
-

--- a/manifests/install/agent.pp
+++ b/manifests/install/agent.pp
@@ -1,0 +1,26 @@
+# Install resource_api module dependencies on a puppet agent.
+
+# A proxy agent needs to be classified with this class before it can use
+# device modules that use the resource_api.
+
+# @summary Install dependencies into the puppet agent
+#
+# @example
+#   include resource_api::install::agent
+#
+# @param [String] api_version A specific release version of Resource API to install
+
+class resource_api::install::agent(
+  String $api_version = 'latest',
+) {
+
+  if versioncmp($facts['puppetversion'], '6.0.0') < 0 {
+    package { 'Resource API on the puppet AIO':
+      ensure   => $api_version,
+      name     => 'puppet-resource_api',
+      provider => puppet_gem,
+    }
+  }
+
+}
+

--- a/manifests/install/agent.pp
+++ b/manifests/install/agent.pp
@@ -1,15 +1,10 @@
-# Install resource_api module dependencies on a puppet agent.
-
-# A proxy agent needs to be classified with this class before it can use
-# device modules that use the resource_api.
-
-# @summary Install dependencies into the puppet agent
+# @summary This class will install the Resource API gem into puppet agent
 #
-# @example
+# @example Declaring the class
 #   include resource_api::install::agent
 #
-# @param [String] api_version A specific release version of Resource API to install
-
+# @param [String]
+#    api_version A specific release version of Resource API to install
 class resource_api::install::agent(
   String $api_version = 'latest',
 ) {

--- a/manifests/install/master.pp
+++ b/manifests/install/master.pp
@@ -1,5 +1,5 @@
-# @summary This class will install the Resource API gem into puppetserver,
-#          and restart the puppetserver service to activate.
+# @summary This class installs the Resource API gem into puppetserver,
+#          and restarts the puppetserver service to activate.
 #
 # @example Declaring the class
 #   include resource_api::install::master
@@ -18,16 +18,12 @@ class resource_api::install::master(
 ) {
 
   # Since PE and Puppet are bundled together, it is enough to only check for the puppet version here.
-
   if versioncmp($facts['puppetversion'], '6.0.0') < 0 {
     package { 'Resource API on the puppetserver':
       ensure   => $api_version,
       name     => 'puppet-resource_api',
       provider => puppetserver_gem,
     }
-
     Package['Resource API on the puppetserver'] ~> $puppetserver_service
   }
-
 }
-

--- a/manifests/install/master.pp
+++ b/manifests/install/master.pp
@@ -1,0 +1,36 @@
+# Install resource_api module dependencies on a puppet master.
+
+# Every master: master of masters, and if present, compile masters and replica
+# needs to be classified with this class before it can compile catalogs for
+# device modules that use the resource_api.
+
+# @summary Install dependencies into the puppetserver service and restart
+#
+# @example
+#   include resource_api::install::master
+#
+# @param [String] api_version A specific release version of Resource API to install
+# @param [Type[Resource]] puppetserver_service The name of the puppetserver service to restart
+
+class resource_api::install::master(
+  String $api_version = 'latest',
+  Type[Resource] $puppetserver_service = $facts['pe_server_version'] ? {
+    /./     => Service['pe-puppetserver'],
+    default => Service['puppetserver']
+  },
+) {
+
+  # Since PE and Puppet are bundled together, it is enough to only check for the puppet version here.
+
+  if versioncmp($facts['puppetversion'], '6.0.0') < 0 {
+    package { 'Resource API on the puppetserver':
+      ensure   => $api_version,
+      name     => 'puppet-resource_api',
+      provider => puppetserver_gem,
+    }
+
+    Package['Resource API on the puppetserver'] ~> $puppetserver_service
+  }
+
+}
+

--- a/manifests/install/master.pp
+++ b/manifests/install/master.pp
@@ -1,17 +1,14 @@
-# Install resource_api module dependencies on a puppet master.
-
-# Every master: master of masters, and if present, compile masters and replica
-# needs to be classified with this class before it can compile catalogs for
-# device modules that use the resource_api.
-
-# @summary Install dependencies into the puppetserver service and restart
+# @summary This class will install the Resource API gem into puppetserver,
+#          and restart the puppetserver service to activate.
 #
-# @example
+# @example Declaring the class
 #   include resource_api::install::master
 #
-# @param [String] api_version A specific release version of Resource API to install
-# @param [Type[Resource]] puppetserver_service The name of the puppetserver service to restart
-
+# @param [String] api_version
+#   A specific release version of Resource API to install
+#
+# @param [Type[Resource]] puppetserver_service
+#   The name of the puppetserver service to restart
 class resource_api::install::master(
   String $api_version = 'latest',
   Type[Resource] $puppetserver_service = $facts['pe_server_version'] ? {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,5 +1,5 @@
-# @summary This class will install the Resource API gem into puppetserver,
-#          and restart the puppetserver service to activate.
+# @summary This class installs the Resource API gem into puppetserver,
+#          and restarts the puppetserver service to activate.
 #
 # @example Declaring the class
 #   include resource_api::server
@@ -19,14 +19,13 @@ class resource_api::server(
   },
 ) {
 
-  # since PE and puppet are bundled together, it is enough to only check for the puppet version here
+  # Since PE and Puppet are bundled together, it is enough to only check for the puppet version here.
   if versioncmp($facts['puppetversion'], '6.0.0') < 0 {
     package { 'Resource API on the puppetserver':
       ensure   => $api_version,
       name     => 'puppet-resource_api',
       provider => puppetserver_gem,
     }
-
     Package['Resource API on the puppetserver'] ~> $puppetserver_service
   }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -10,6 +10,9 @@
 #
 # @param [String] api_version A specific release version of Resource API to install
 # @param [Type[Resource]] puppetserver_service  The name of the puppetserver service to reboot
+#
+# Deprecated by resource_api::install::master
+
 class resource_api::server(
   String $api_version = 'latest',
   Type[Resource] $puppetserver_service = $facts['pe_server_version'] ? {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,18 +1,16 @@
-# resource_api::server
-#
-# Install dependencies onto the server
-#
-# @summary  This class will install the Resource API gem onto the server and perform
-#           a reboot of the server.
+# @summary This class will install the Resource API gem into puppetserver,
+#          and restart the puppetserver service to activate.
 #
 # @example Declaring the class
 #   include resource_api::server
 #
-# @param [String] api_version A specific release version of Resource API to install
-# @param [Type[Resource]] puppetserver_service  The name of the puppetserver service to reboot
+# @param [String] api_version
+#   A specific release version of Resource API to install
 #
-# Deprecated by resource_api::install::master
-
+# @param [Type[Resource]] puppetserver_service
+#   The name of the puppetserver service to reboot
+#
+# @note Deprecated, use resource_api::install::server
 class resource_api::server(
   String $api_version = 'latest',
   Type[Resource] $puppetserver_service = $facts['pe_server_version'] ? {


### PR DESCRIPTION
With this commit ...

Simply including the module will include the ::install class.
The ::install class will install dependencies on agent or master.

(A custom puppetserver_installed fact is defined to detect a master.)

Optionally, the ::install::agent and ::install::master classes can be declared
directly, allowing the user to specify their parameters ... if any.

Keep manifests/*.pp to allow for a transition to these classes.