### PR TITLE
(maint) removing the secure string

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -10,7 +10,6 @@
     - set: docker/ubuntu-14.04
   docker_defaults:
     bundler_args: ""
-  secure: ""
   branches:
     - release
   notifications:


### PR DESCRIPTION
The secure string causes the deploy stage to be added to the travis build on tags, as our team uses jenkins for deployment to forge, we no longer need it on travis.