### PR TITLE
pdksync - (maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,24 +15,30 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "6",
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
+        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "6",
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
+        "6",
         "7"
       ]
     },
@@ -40,20 +46,26 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+        "14.04",
+        "16.04",
+        "18.04",
+        "20.04"
       ]
     },
     {
-      "operatingsystem": "windows",
+      "operatingsystem": "Windows",
       "operatingsystemrelease": [
         "2008 R2",
         "2012 R2",
+        "2016",
+        "2019",
         "10"
       ]
     },
@@ -72,7 +84,7 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "12"
+        "15"
       ]
     },
     {


### PR DESCRIPTION
(maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json
pdk version: `1.18.1` 
